### PR TITLE
Handling inverses

### DIFF
--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -183,9 +183,9 @@ class GraphInterface:
             element = self.toolkit.get_element(biolink_predicate)
             if element is None:
                 return None
-            if 'inverse' not in element:
+            if 'inverse' not in element or not element['inverse']:
                 return None
-            return element['inverse']
+            return self.toolkit.get_element(element['inverse']).slot_uri
 
         def get_schema(self):
             """
@@ -238,14 +238,14 @@ class GraphInterface:
                         schema_bag[subject][objct] = []
                     if predicate not in schema_bag[subject][objct]:
                         schema_bag[subject][objct].append(predicate)
-                    # do reverse
-                    if objct not in schema_bag:
-                        schema_bag[objct] = {}
-                    if subject not in schema_bag[objct]:
-                        schema_bag[objct][subject] = []
+
                     #If we invert the order of the nodes we also have to invert the predicate
                     inverse_predicate = self.invert_predicate(predicate)
                     if inverse_predicate is not None and inverse_predicate not in schema_bag[objct][subject]:
+                        if objct not in schema_bag:
+                            schema_bag[objct] = {}
+                        if subject not in schema_bag[objct]:
+                            schema_bag[objct][subject] = []
                         schema_bag[objct][subject].append(inverse_predicate)
                 self.schema = schema_bag
                 logger.info("schema done.")

--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -241,7 +241,9 @@ class GraphInterface:
 
                     #If we invert the order of the nodes we also have to invert the predicate
                     inverse_predicate = self.invert_predicate(predicate)
-                    if inverse_predicate is not None and inverse_predicate not in schema_bag[objct][subject]:
+                    if inverse_predicate is not None and \
+                            inverse_predicate not in schema_bag.get(objct,{}).get(subject,[]):
+                        # create the list if empty
                         if objct not in schema_bag:
                             schema_bag[objct] = {}
                         if subject not in schema_bag[objct]:

--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -178,6 +178,15 @@ class GraphInterface:
             leaf_set = all_concepts - ancestry_set
             return leaf_set
 
+        def invert_predicate(self, biolink_predicate):
+            """Given a biolink predicate, find its inverse"""
+            element = self.toolkit.get_element(biolink_predicate)
+            if element is None:
+                return None
+            if 'inverse' not in element:
+                return None
+            return element['inverse']
+
         def get_schema(self):
             """
             Gets the schema of the graph. To be used by. Also generates graph summary
@@ -234,8 +243,10 @@ class GraphInterface:
                         schema_bag[objct] = {}
                     if subject not in schema_bag[objct]:
                         schema_bag[objct][subject] = []
-                    if predicate not in schema_bag[objct][subject]:
-                        schema_bag[objct][subject].append(predicate)
+                    #If we invert the order of the nodes we also have to invert the predicate
+                    inverse_predicate = self.invert_predicate(predicate)
+                    if inverse_predicate is not None and inverse_predicate not in schema_bag[objct][subject]:
+                        schema_bag[objct][subject].append(inverse_predicate)
                 self.schema = schema_bag
                 logger.info("schema done.")
                 if not self.summary:

--- a/PLATER/tests/data/graph_schema.json
+++ b/PLATER/tests/data/graph_schema.json
@@ -1,12 +1,15 @@
 {
-  "chemical_substance": {
-      "gene": [
-          "directly_interacts_with"
+  "biolink:ChemicalSubstance": {
+      "biolink:Gene": [
+          "biolink:directly_interacts_with"
+      ],
+    "biolink:Disease": [
+        "biolink:treats"
       ]
   },
-  "gene": {
-      "disease": [
-          "has_basis_in"
+  "biolink:Gene": {
+      "biolink:Disease": [
+          "biolink:has_basis_in"
       ]
   }
  }


### PR DESCRIPTION
When building predicates/schema, it's correct to swap subject and object, but when we do that, we also need to invert the predicate, so 
(A)-[treats]->(B) 
becomes
(A)<-[treated by]-(B)