### PR TITLE
Mixin inclusion

### DIFF
--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -173,11 +173,24 @@ class GraphInterface:
             :return: leave concepts.
             """
             ancestry_set = set()
+            all_mixins_in_tree = set()
             all_concepts = set(biolink_concepts)
+            # Keep track of things like "MacromolecularMachine" in current datasets.
+            unknown_elements = set()
+
             for x in all_concepts:
+                current_element = self.toolkit.get_element(x)
+                mixins = set()
+                if current_element:
+                    if 'mixins' in current_element and len(current_element['mixins']):
+                        for m in current_element['mixins']:
+                            mixins.add(self.toolkit.get_element(m).class_uri)
+                else:
+                    unknown_elements.add(x)
                 ancestors = set(self.toolkit.get_ancestors(x, reflexive=False, formatted=True))
                 ancestry_set = ancestry_set.union(ancestors)
-            leaf_set = all_concepts - ancestry_set
+                all_mixins_in_tree = all_mixins_in_tree.union(mixins)
+            leaf_set = all_concepts - ancestry_set - all_mixins_in_tree - unknown_elements
             return leaf_set
 
         def invert_predicate(self, biolink_predicate):
@@ -447,3 +460,8 @@ class GraphInterface:
     def __getattr__(self, item):
         # proxy function calls to the inner object.
         return getattr(self.instance, item)
+
+if __name__ == '__main__':
+    toolkit = Toolkit('https://raw.githubusercontent.com/biolink/biolink-model/1.5.0/biolink-model.yaml')
+    x = toolkit.get_element('biolink:GeneOrGeneProduct')
+    print(x)

--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -162,7 +162,9 @@ class GraphInterface:
             self.driver = Neo4jHTTPDriver(host=host, port=port, auth=auth)
             self.schema = None
             self.summary = None
-            self.toolkit = Toolkit()
+            self.bl_version = config.get('BL_VERSION', '1.5.0')
+            self.bl_url = f'https://raw.githubusercontent.com/biolink/biolink-model/{self.bl_version}/biolink-model.yaml'
+            self.toolkit = Toolkit(self.bl_url)
 
         def find_biolink_leaves(self, biolink_concepts: list):
             """
@@ -183,8 +185,13 @@ class GraphInterface:
             element = self.toolkit.get_element(biolink_predicate)
             if element is None:
                 return None
+            # If its symmetric
+            if 'symmetric' in element and element.symmetric:
+                return biolink_predicate
+            # if neither symmetric nor an inverse is found
             if 'inverse' not in element or not element['inverse']:
                 return None
+            # if an inverse is found
             return self.toolkit.get_element(element['inverse']).slot_uri
 
         def get_schema(self):

--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -460,8 +460,3 @@ class GraphInterface:
     def __getattr__(self, item):
         # proxy function calls to the inner object.
         return getattr(self.instance, item)
-
-if __name__ == '__main__':
-    toolkit = Toolkit('https://raw.githubusercontent.com/biolink/biolink-model/1.5.0/biolink-model.yaml')
-    x = toolkit.get_element('biolink:GeneOrGeneProduct')
-    print(x)


### PR DESCRIPTION
* Filters mix-ins,  out of current labels on a node.
* Mix-ins are collected from each type in the current concept and used similarly as ancestors are used. 
* Some times there are types in current data sets that are no being resolved by toolkit (1.5.0 biolink version), such as `biolink:MacromolecularMachine` type,  at those instances a separate list and it also prevents them from showing up on the graph schema (predicates end point).