### PR TITLE
Update graph_adapter.py

### DIFF
--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -110,7 +110,7 @@ class Neo4jHTTPDriver:
         response = httpx.post(
             self._full_transaction_path,
             headers=self._header,
-            timeout=600,
+            timeout=1500,
             json=payload).json()
         errors = response.get('errors')
         if errors:


### PR DESCRIPTION
Increases httpx timeout for generating predicates on large graphs.
- Testing covidkop kg behind plater it takes about ~20 mins to generate predicates.