### PR TITLE
support for neo4j 4 (http api change patch)

### DIFF
--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -49,8 +49,8 @@ class Neo4jHTTPDriver:
         Pings the neo4j backend.
         :return:
         """
-        neo4j_db_labels_endpoint = "/db/data/labels"
-        ping_url = f"{self._scheme}://{self._host}:{self._port}{neo4j_db_labels_endpoint}"
+        neo4j_test_connection_endpoint = ""
+        ping_url = f"{self._scheme}://{self._host}:{self._port}/{neo4j_test_connection_endpoint}"
         # if we can't contact neo4j, we should exit.
         try:
             import time


### PR DESCRIPTION
Ping api endpoint for testing neo4j prevously used db/labels which is no longer available on 4.0+ versions of neo4j. 
This PR just checks for root endpoint 