### PR TITLE
Docker file causing stale mounts in k8s env

### DIFF
--- a/PLATER/Dockerfile
+++ b/PLATER/Dockerfile
@@ -12,7 +12,6 @@ COPY ./requirements.txt PLATER/requirements.txt
 RUN pip install --upgrade pip
 RUN pip install -r PLATER/requirements.txt
 EXPOSE 8080
-VOLUME logs
 RUN mkdir -p PLATER/logs
 RUN chown plater:plater PLATER/logs
 USER plater


### PR DESCRIPTION
Latest k8s runtime error out that this logs volume needs to absolute path. There is no real need for it. removing it.