### PR TITLE
Return raw json for 1.1 path

### DIFF
--- a/PLATER/services/app_trapi_1_1.py
+++ b/PLATER/services/app_trapi_1_1.py
@@ -32,7 +32,7 @@ async def reasoner_api(
     question = Question(request_json["message"])
     response = await question.answer(graph_interface)
     request_json.update({'message': response})
-    return request_json
+    return JSONResponse(request_json)
 
 
 APP_TRAPI_1_1.add_api_route(


### PR DESCRIPTION
When returning a dict reasoner paydanic would parse and add null values to the response. We can avoid that via returning a json response intead.