### PR TITLE
Use get ancestors to resolve mixin hierarchy aswell

### DIFF
--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -178,24 +178,17 @@ class GraphInterface:
             :return: leave concepts.
             """
             ancestry_set = set()
-            all_mixins_in_tree = set()
             all_concepts = set(biolink_concepts)
             # Keep track of things like "MacromolecularMachine" in current datasets.
             unknown_elements = set()
 
             for x in all_concepts:
                 current_element = self.toolkit.get_element(x)
-                mixins = set()
-                if current_element:
-                    if 'mixins' in current_element and len(current_element['mixins']):
-                        for m in current_element['mixins']:
-                            mixins.add(self.toolkit.get_element(m).class_uri)
-                else:
+                if not current_element:
                     unknown_elements.add(x)
-                ancestors = set(self.toolkit.get_ancestors(x, reflexive=False, formatted=True))
+                ancestors = set(self.toolkit.get_ancestors(x, mixin=True, reflexive=False, formatted=True))
                 ancestry_set = ancestry_set.union(ancestors)
-                all_mixins_in_tree = all_mixins_in_tree.union(mixins)
-            leaf_set = all_concepts - ancestry_set - all_mixins_in_tree - unknown_elements
+            leaf_set = all_concepts - ancestry_set - unknown_elements
             return leaf_set
 
         def invert_predicate(self, biolink_predicate):


### PR DESCRIPTION
When looking up type ancestors when computing graph schema, we used to have to manually lookup for mixins aswell and remove them from the final schema to make it as specific as possible. 

Eg Node can have the following labels in neo4j:
``` 
['biolink:Entity', 'biolink:PhysicalEssence', 'biolink:ChemicalEntity', 'biolink:PhysicalEssenceOrOccurrent', 'biolink:SmallMolecule', 'biolink:MolecularEntity']
 ```
 
We would like to use only leaf types in the meta KG, so we ought to remove the ancestors of all these types this would also include mixin ancestors such as PhysicalEssenceOrOccurent : 
``` 
{'biolink:ChemicalEntity', 'biolink:ChemicalEntityOrGeneOrGeneProduct', 'biolink:PhysicalEssence', 'biolink:NamedThing', 'biolink:Entity', 'biolink:ChemicalOrDrugOrTreatment', 'biolink:MolecularEntity', 'biolink:ChemicalEntityOrProteinOrPolypeptide', }
```


For this example our final leaf type would be SmallMolecule. 

Things like `chemical or drug or treatment` are returned by get_ancestors method when supplied with mixin=True argument.
