### PR TITLE
Feature/node attributes

### DIFF
--- a/PLATER/Dockerfile
+++ b/PLATER/Dockerfile
@@ -1,9 +1,5 @@
-FROM python:3.8.5
+FROM renciorg/renci-python-image:v0.0.1
 
-ARG UID=1000
-ARG GID=1000
-RUN groupadd -o -g $GID plater
-RUN useradd -m -u $UID -g $GID -s /bin/bash plater
 WORKDIR /home/plater
 RUN git clone https://github.com/TranslatorSRI/Plater.git
 WORKDIR /home/plater/Plater
@@ -13,6 +9,6 @@ RUN pip install --upgrade pip
 RUN pip install -r PLATER/requirements.txt
 EXPOSE 8080
 RUN mkdir -p PLATER/logs
-RUN chown plater:plater PLATER/logs
-USER plater
+RUN chown nru:nru PLATER/logs
+USER nru
 ENTRYPOINT ["./main.sh"]

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -10,7 +10,7 @@ from PLATER.services.app_trapi_1_2 import APP_TRAPI_1_2
 from PLATER.services.util.api_utils import construct_open_api_schema
 
 TITLE = config.get('PLATER_TITLE', 'Plater API')
-VERSION = os.environ.get('PLATER_VERSION', '1.2.0-7')
+VERSION = os.environ.get('PLATER_VERSION', '1.2.0-9')
 
 logger = LoggingUtil.init_logging(
     __name__,

--- a/PLATER/services/util/attribute_mapping.py
+++ b/PLATER/services/util/attribute_mapping.py
@@ -1,0 +1,59 @@
+import json
+import os
+from bmt import Toolkit
+
+bmt_toolkit = Toolkit()
+# load the attrib and value mapping file
+map_data = json.load(open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..", "..", "attr_val_map.json")))
+
+# attribute skip list
+skip_list = json.load(open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..", "..", "skip_attr.json")))
+
+# set the value type mappings
+VALUE_TYPES = map_data['value_type_map']
+
+
+def get_attribute_bl_info(attribute_name):
+    # set defaults
+    new_attr_meta_data = {
+        "attribute_type_id": "biolink:Attribute",
+        "value_type_id": "EDAM:data_0006",
+    }
+    # if attribute is meant to b6e skipped return none
+    if attribute_name in skip_list or attribute_name in ["name", "id"]:
+        return None
+
+    # map the attribute type to the list above, otherwise generic default
+    new_attr_meta_data["value_type_id"] = VALUE_TYPES.get(attribute_name, new_attr_meta_data["value_type_id"])
+    attr_found = None
+    if attribute_name in map_data["attribute_type_map"]:
+        attr_found = True
+        new_attr_meta_data["attribute_type_id"] = map_data["attribute_type_map"][attribute_name]
+    if attribute_name in map_data["value_type_map"]:
+        new_attr_meta_data["value_type_id"] = map_data["value_type_map"][attribute_name]
+    if attr_found:
+        return new_attr_meta_data
+
+    # lookup the biolink info
+    bl_info = bmt_toolkit.get_element(attribute_name)
+
+    # did we get something
+    if bl_info is not None:
+        # if there are exact mappings use the first on
+        if 'slot_uri' in bl_info:
+            new_attr_meta_data['attribute_type_id'] = bl_info['slot_uri']
+            # was there a range value
+            if 'range' in bl_info and bl_info['range'] is not None:
+                # try to get the type of data
+                new_type = bmt_toolkit.get_element(bl_info['range'])
+                # check if new_type is not None. For eg. bl_info['range'] = 'uriorcurie' for things
+                # for `relation` .
+                if new_type:
+                    if 'uri' in new_type and new_type['uri'] is not None:
+                        # get the real data type
+                        new_attr_meta_data["value_type_id"] = new_type['uri']
+        elif 'class_uri' in bl_info:
+            new_attr_meta_data['attribute_type_id'] = bl_info['class_uri']
+    return new_attr_meta_data
+
+

--- a/PLATER/services/util/overlay.py
+++ b/PLATER/services/util/overlay.py
@@ -91,7 +91,7 @@ class Overlay:
                     })
             new_edge['attributes'] = attributes
 
-            edge = Question({}).format_attribute_trapi({'edge': new_edge}, self.graph_interface)['edge']
+            edge = Question({}).format_attribute_trapi({'edge': new_edge})['edge']
             source_id = edge['subject']
             target_id = edge['object']
             m = result.get(source_id, {})

--- a/PLATER/tests/test_graph_adapter.py
+++ b/PLATER/tests/test_graph_adapter.py
@@ -203,18 +203,19 @@ async def test_get_meta_kg(httpx_mock: HTTPXMock):
         ]
       }
     }
+    node_attributes = [{"attribute_type_id": "biolink:same_as"}]
     def patch_get_node_curies(node_type):
         # mimic db return ids then filter curie prefixes
         if node_type == "biolink:Disease":
-            return ['MONDO']
+            return ['MONDO'] , node_attributes
         if node_type == "biolink:PhenotypicFeature":
-            return ['HP']
+            return ['HP'], node_attributes
     gi.instance.get_curie_prefix_by_node_type = patch_get_node_curies
 
     assert await gi.get_meta_kg() == {
         "nodes": {
-            "biolink:Disease": { "id_prefixes": ['MONDO']},
-            "biolink:PhenotypicFeature":{ "id_prefixes": ['HP']}
+            "biolink:Disease": { "id_prefixes": ['MONDO'], "attributes": node_attributes},
+            "biolink:PhenotypicFeature":{ "id_prefixes": ['HP'], "attributes": node_attributes}
         }, "edges": [
             { "subject": "biolink:Disease", "object": "biolink:PhenotypicFeature", "predicate": "biolink:has_phenotype"},
             { "object": "biolink:Disease", "subject": "biolink:Disease", "predicate": "biolink:has_phenotype"},

--- a/PLATER/tests/test_overlay.py
+++ b/PLATER/tests/test_overlay.py
@@ -18,6 +18,9 @@ def graph_interface_apoc_supported():
                         'predicate': 'biolink:related_to',
                         'edge': {
                             'id': 'SUPPORT_EDGE_KG_ID_1',
+                            'predicate': 'biolink:related_to',
+                            'subject': 'NODE:0',
+                            'object': 'NODE:2',
                             'attr_1': [],
                             'attr_2': {}
                         }
@@ -26,8 +29,10 @@ def graph_interface_apoc_supported():
                         'object': 'NODE:22',
                         'predicate': 'biolink:related_to',
                         'edge': {
-                            'type': 'biolink:related_to',
+                            'predicate': 'biolink:related_to',
                             'id': 'SUPPORT_EDGE_KG_ID_2',
+                            'subject': 'NODE:00',
+                            'object': 'NODE:22',
                             'attr_1': [],
                             'attr_2': {}
                         }
@@ -37,7 +42,9 @@ def graph_interface_apoc_supported():
                         'object': 'NODE:22',
                         'predicate': 'biolink:related_to',
                         'edge': {
-                            'type': 'biolink:related_to',
+                            'subject': 'NODE:0',
+                            'object': 'NODE:22',
+                            'predicate': 'biolink:related_to',
                             'id': 'SUPPORT_EDGE_KG_ID_3'
                         }
                     }
@@ -131,7 +138,7 @@ def get_kg_ids(bindings):
 def test_overlay_adds_support_bindings(graph_interface_apoc_supported, reasoner_json):
     ov = Overlay(graph_interface=graph_interface_apoc_supported)
     event_loop = asyncio.get_event_loop()
-    response = event_loop.run_until_complete(ov.overlay_support_edges(reasoner_json))
+    response = event_loop.run_until_complete(ov.connect_k_nodes(reasoner_json))
     edges = response['knowledge_graph']['edges']
     edge_ids = edges.keys()
     assert len(edge_ids) == 2

--- a/PLATER/tests/test_question.py
+++ b/PLATER/tests/test_question.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 from PLATER.services.util.question import Question
 from bmt import Toolkit
-import asyncio
+import asyncio, json
 
 def test_init():
     reasoner_dict = {
@@ -51,7 +51,7 @@ def test_format_attribute():
     t2_expected_trapi = {'knowledge_graph': {'nodes': {'CURIE:1': {'attributes': [
         {'original_attribute_name': 'pub', 'value': 'x', 'value_type_id': 'EDAM:data_0006', 'attribute_type_id': 'preserved_attrib'},
         {'original_attribute_name': 'publications', 'value': 'x', 'value_type_id': 'EDAM:data_0006', 'attribute_type_id': 'biolink:publications'},
-        {'original_attribute_name': 'endogenous', 'value': 'false', 'value_type_id': 'xsd:boolean', 'attribute_type_id': 'biolink:Attribute'},
+        {'original_attribute_name': 'endogenous', 'value': 'false', 'value_type_id': 'xsd:boolean', 'attribute_type_id': 'aragorn:endogenous'},
         {'original_attribute_name': 'p-value', 'value': '1.234', 'value_type_id': 'EDAM:data_0006', 'attribute_type_id': 'biolink:Attribute'},
         {'original_attribute_name': 'chi-squared-statistic', 'value': '2.345', 'value_type_id': 'EDAM:data_0006', 'attribute_type_id': 'biolink:Attribute'},
         {"original_attribute_name": "equivalent_identifiers", "attribute_type_id": "biolink:same_as", "value": ["some_identifier"], 'value_type_id': 'metatype:uriorcurie'},
@@ -82,7 +82,7 @@ class MOCK_GRAPH_ADAPTER():
 
 
 def test_answer():
-    def compile_cypher_mock():
+    def compile_cypher_mock(**kwargs):
         return "SOME CYPHER"
     question = Question({"query_graph": {}})
     question.compile_cypher = compile_cypher_mock


### PR DESCRIPTION
- Scans graph nodes neo4j attributes and converts them into biolink type attributes (https://github.com/RENCI-AUTOMAT/Automat-server/issues/34)
```
{
  "nodes": {
    "biolink:PhenotypicFeature": {
      "id_prefixes": [
        "HP"
      ],
      "attributes": [
        {
          "attribute_type_id": "biolink:same_as",
          "attribute_source": null,
          "original_attribute_names": [
            "equivalent_identifiers"
          ],
          "constraint_use": false,
          "constraint_name": null
        },
        {
          "attribute_type_id": "biolink:Attribute",
          "attribute_source": null,
          "original_attribute_names": [
            "synonyms"
          ],
          "constraint_use": false,
          "constraint_name": null
        }
      ]
    },
    "biolink:Disease": {
      "id_prefixes": [
        "MONDO"
      ],
      .... 
```
- `name` and `id` attributes are not going to be listed here, as these will be core attributes , known to be there always. 
- Moves neo4j-attribute label to biolink conversion logic as a sharable module to be used in both schema creation , and question answering 
- Fixes broken overlay tests, 
- Updates docker image 
