### PR TITLE
adding attribute source to EPC attributes

### DIFF
--- a/PLATER/services/util/question.py
+++ b/PLATER/services/util/question.py
@@ -43,7 +43,7 @@ class Question:
         return get_query(self._question_json[Question.QUERY_GRAPH_KEY],**kwargs)
 
     # @staticmethod
-    def format_attribute_trapi(self, kg_items):
+    def format_attribute_trapi(self, kg_items, node=False):
         for identifier in kg_items:
             # get the properties for the record
             props = kg_items[identifier]
@@ -74,15 +74,16 @@ class Question:
             # create a provenance attribute for plater
             provenance_attrib = {
                 "attribute_type_id": "biolink:aggregator_knowledge_source",
-                "value": self.provenance,
+                "value": [self.provenance],
                 "value_type_id": "biolink:InformationResource",
                 "original_attribute_name": "biolink:aggregator_knowledge_source"
             }
 
             # add plater provenance to the list
-            new_attribs.append(provenance_attrib)
+            if not node:
+                # Adds attribute source for provenance attributes to edges.
+                new_attribs.append(provenance_attrib)
 
-            # Adds attribute source for provenance attributes.
             # setting this to self provenance (eg. infores:automat-biolink).
             for attribute in new_attribs:
                 if attribute.get('attribute_type_id') in [
@@ -98,7 +99,7 @@ class Question:
         return kg_items
 
     def transform_attributes(self, trapi_message, graph_interface: GraphInterface):
-        self.format_attribute_trapi(trapi_message.get('knowledge_graph', {}).get('nodes', {}))
+        self.format_attribute_trapi(trapi_message.get('knowledge_graph', {}).get('nodes', {}), node=True)
         self.format_attribute_trapi(trapi_message.get('knowledge_graph', {}).get('edges', {}))
         return trapi_message
 

--- a/PLATER/services/util/question.py
+++ b/PLATER/services/util/question.py
@@ -82,6 +82,16 @@ class Question:
             # add plater provenance to the list
             new_attribs.append(provenance_attrib)
 
+            # Adds attribute source for provenance attributes.
+            # setting this to self provenance (eg. infores:automat-biolink).
+            for attribute in new_attribs:
+                if attribute.get('attribute_type_id') in [
+                    "biolink:original_knowledge_source",
+                    "biolink:primary_knowledge_source",
+                    "biolink:aggregator_knowledge_source"
+                ] and attribute.get('value_type_id') == "biolink:InformationResource":
+                    attribute['attribute_source'] = self.provenance
+
             # assign these attribs back to the original attrib list without the core properties
             props['attributes'] = new_attribs
 

--- a/PLATER/services/util/question.py
+++ b/PLATER/services/util/question.py
@@ -92,6 +92,8 @@ class Question:
                     "biolink:aggregator_knowledge_source"
                 ] and attribute.get('value_type_id') == "biolink:InformationResource":
                     attribute['attribute_source'] = self.provenance
+                    # convert to list for uniformity
+                    attribute['value'] = [attribute['value']] if isinstance(attribute['value'], str) else attribute['value']
 
             # assign these attribs back to the original attrib list without the core properties
             props['attributes'] = new_attribs

--- a/README.md
+++ b/README.md
@@ -112,13 +112,14 @@ Plater tries to resolve attibute types and value types for edges and nodes in th
             }
     ```
   
- 2. In cases where there are attributes in neo4j that are not specified in attr_val_map.json, PLATER will try to resolve a biolink class by using the original attribute name using Biolink model toolkit. 
- 3. If the above steps fail the attribute will be presented having `"attribute_type_id": "biolink:Attribute"` and `"value_type_id": "EDAM:data_0006"`
- 4. If there are attributes that is not needed for presentation through TRAPI [Skip_attr.json](https://github.com/TranslatorSRI/Plater/blob/master/skip_attr.json) can be used to specify attribute names in neo4j to skip. 
+2. In cases where there are attributes in neo4j that are not specified in attr_val_map.json, PLATER will try to resolve a biolink class by using the original attribute name using Biolink model toolkit. 
+3. If the above steps fail the attribute will be presented having `"attribute_type_id": "biolink:Attribute"` and `"value_type_id": "EDAM:data_0006"`
+4. If there are attributes that is not needed for presentation through TRAPI [Skip_attr.json](https://github.com/TranslatorSRI/Plater/blob/master/skip_attr.json) can be used to specify attribute names in neo4j to skip.
+   KGX loading adds a new attributes `provided_by` and `knowledge_source` to nodes and edges respectively, which are the file name used to load the graph. By default, we have included these to the skip list. 
  
 ### Provenance 
 ------------
-By setting `PROVENANCE_TAG` environment variable to something like `infores:automat.ctd` , PLATER will return provenance information on edges and nodes.
+By setting `PROVENANCE_TAG` environment variable to something like `infores:automat.ctd` , PLATER will return provenance information on edges.
 
 ## Installation
 

--- a/skip_attr.json
+++ b/skip_attr.json
@@ -1,1 +1,4 @@
-[]
+[
+  "provided_by",
+  "knowledge_source"
+]


### PR DESCRIPTION
This PR sets `attribute_source` for provenance attributes to the current plater instance name.  (https://github.com/TranslatorSRI/Plater/issues/66) 

Eg of an output 
```
    "knowledge_graph": {
      "nodes": {
        "NCBIGene:1714": {
          "categories": ...
          "name": "DiGeorge sequence",
          "attributes": [
            {
              "attribute_type_id": "biolink:provided_by",
              "value": [
                "merge_nodes.jsonl"
              ],
              "value_type_id": "EDAM:data_0006",
              "original_attribute_name": "provided_by",
              "value_url": null,
              "attribute_source": null,
              "description": null,
              "attributes": null
            },....
            {
              "attribute_type_id": "biolink:aggregator_knowledge_source",
              "value": "infores:automat.notspecified",
              "value_type_id": "biolink:InformationResource",
              "original_attribute_name": "biolink:aggregator_knowledge_source",
              "value_url": null,
              "attribute_source": "infores:automat.notspecified",
              "description": null,
              "attributes": null
            }
          ]
        },
        "MONDO:0009010":  ...
      },
      "edges": {
        "b9614111fb4ce63393463c0b09474341": {
          "subject": "NCBIGene:1714",
          "object": "MONDO:0009010",
          "predicate": "biolink:has_phenotype",
          "attributes": [
            {
              "attribute_type_id": "biolink:knowledge_source",
              "value": [
                "merge_edges.jsonl"
              ],
              "value_type_id": "EDAM:data_0006",
              "original_attribute_name": "knowledge_source",
              "value_url": null,
              "attribute_source": null,
              "description": null,
              "attributes": null
            },
            {
              "attribute_type_id": "biolink:aggregator_knowledge_source",
              "value": [
                "infores:sri-reference-kg"
              ],
              "value_type_id": "biolink:InformationResource",
              "original_attribute_name": "biolink:aggregator_knowledge_source",
              "value_url": null,
              "attribute_source": "infores:automat.notspecified",
              "description": null,
              "attributes": null
            },
            {
              "attribute_type_id": "biolink:relation",
              "value": "RO:0002200",
              "value_type_id": "EDAM:data_0006",
              "original_attribute_name": "relation",
              "value_url": null,
              "attribute_source": null,
              "description": null,
              "attributes": null
            },
            {
              "attribute_type_id": "biolink:aggregator_knowledge_source",
              "value": "infores:automat.notspecified",
              "value_type_id": "biolink:InformationResource",
              "original_attribute_name": "biolink:aggregator_knowledge_source",
              "value_url": null,
              "attribute_source": "infores:automat.notspecified",
              "description": null,
              "attributes": null
            }
          ]
        }
      }
    }
```
( infores:automat.notspecified  is the default local server kp name , in prod this would be an actual instance name)