### PR TITLE
Qualifiers output

### DIFF
--- a/PLATER/examples/reasoner-trapi-1.3.json
+++ b/PLATER/examples/reasoner-trapi-1.3.json
@@ -1,0 +1,53 @@
+{
+   "message": {
+      "query_graph": {
+          "nodes": {
+            "n0": {
+              "categories": [
+                "biolink:ChemicalEntity"
+              ],
+              "ids": [
+                "CHEMBL.COMPOUND:CHEMBL3234626",
+                "CHEMBL.COMPOUND:CHEMBL3234633"
+              ]
+            },
+            "n1": {
+              "categories": [
+                "biolink:GeneOrGeneProduct"
+              ],
+              "ids": [
+                "NCBIGene:2099"
+              ]
+            }
+          },
+          "edges": {
+            "e01": {
+              "subject": "n0",
+              "object": "n1",
+              "predicates": [
+                "biolink:affects"
+              ],
+              "qualifier_constraints": [
+                {
+                  "qualifier_set": [
+                    {
+                      "qualifier_type_id": "biolink:object_aspect_qualifier",
+                      "qualifier_value": "activity"
+                    },
+                    {
+                      "qualifier_type_id": "biolink:object_direction_qualifier",
+                      "qualifier_value": "increased"
+                    },
+                    {
+                      "qualifier_type_id": "biolink:qualified_predicate",
+                      "qualifier_value": "biolink:causes"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+      }
+   },
+   "workflow": [{"id":  "lookup"}]
+}

--- a/PLATER/services/app_trapi_1_3.py
+++ b/PLATER/services/app_trapi_1_3.py
@@ -33,7 +33,7 @@ async def reasoner_api(
         request: ReasonerRequest = Body(
             ...,
             # Works for now but in deployment would be replaced by a mount, specific to backend dataset
-            example=get_example("reasoner-trapi-1.2"),
+            example=get_example("reasoner-trapi-1.3"),
         ),
         graph_interface: GraphInterface = Depends(get_graph_interface),
 ):

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -11,7 +11,7 @@ from PLATER.services.util.api_utils import construct_open_api_schema
 
 TITLE = config.get('PLATER_TITLE', 'Plater API')
 
-VERSION = os.environ.get('PLATER_VERSION', '1.3.0-9')
+VERSION = os.environ.get('PLATER_VERSION', '1.3.0-10')
 
 
 logger = LoggingUtil.init_logging(

--- a/PLATER/services/util/api_utils.py
+++ b/PLATER/services/util/api_utils.py
@@ -29,7 +29,7 @@ def get_bl_helper():
 
 def construct_open_api_schema(app, trapi_version, prefix=""):
     plater_title = config.get('PLATER_TITLE', 'Plater API')
-    plater_version = os.environ.get('PLATER_VERSION', '1.3.0-9')
+    plater_version = os.environ.get('PLATER_VERSION', '1.3.0-10')
     server_url = os.environ.get('PUBLIC_URL')
     if app.openapi_schema:
         return app.openapi_schema

--- a/PLATER/services/util/graph_adapter.py
+++ b/PLATER/services/util/graph_adapter.py
@@ -513,31 +513,12 @@ class GraphInterface:
                                 }
                                 if has_qualifiers:
                                     qualifiers = []
-                                    if "qualified_predicate" in neo4j_edge:
-                                        qualifiers.append({
-                                            "qualifier_type_id": "biolink:qualified_predicate",
-                                            "qualifier_value": neo4j_edge["qualified_predicate"]
-                                        })
-                                    if "subject_direction_qualifier" in neo4j_edge:
-                                        qualifiers.append({
-                                            "qualifier_type_id": "biolink:subject_direction_qualifier",
-                                            "qualifier_value": neo4j_edge["subject_direction_qualifier"]
-                                        })
-                                    if "subject_aspect_qualifier" in neo4j_edge:
-                                        qualifiers.append({
-                                            "qualifier_type_id": "biolink:subject_aspect_qualifier",
-                                            "qualifier_value": neo4j_edge["subject_aspect_qualifier"]
-                                        })
-                                    if "object_direction_qualifier" in neo4j_edge:
-                                        qualifiers.append({
-                                            "qualifier_type_id": "biolink:object_direction_qualifier",
-                                            "qualifier_value": neo4j_edge["object_direction_qualifier"]
-                                        })
-                                    if "object_aspect_qualifier" in neo4j_edge:
-                                        qualifiers.append({
-                                            "qualifier_type_id": "biolink:object_aspect_qualifier",
-                                            "qualifier_value": neo4j_edge["object_aspect_qualifier"]
-                                        })
+                                    for prop in neo4j_edge:
+                                        if 'qualifie' in prop:
+                                            qualifiers.append({
+                                                "qualifier_type_id": f"biolink:{prop}" if not prop.startswith("biolink:") else prop,
+                                                "qualifier_value": neo4j_edge[prop]
+                                            })
                                     if qualifiers:
                                         test_edge["qualifiers"] = qualifiers
                                 test_edges.append(test_edge)

--- a/PLATER/services/util/question.py
+++ b/PLATER/services/util/question.py
@@ -52,6 +52,7 @@ class Question:
         edges = query_graph.get('edges')
         for e in edges:
             # removes "biolink:" from constraint names. since these are not encoded in the graph.
+            # TODO revert this when we switch to having biolink: in the graphs
             if edges[e]['qualifier_constraints']:
                 for qualifier in edges[e]['qualifier_constraints']:
                     for item in qualifier['qualifier_set']:
@@ -67,10 +68,26 @@ class Question:
             # save the transpiler attribs
             attributes = props.get('attributes', [])
 
-            # create a new list that doesnt have the core properties
+            # separate the qualifiers from attributes for edges and format them
+            if not node:
+                qualifier_results = [attrib for attrib in attributes
+                                     if 'qualifie' in attrib['original_attribute_name']]
+                if qualifier_results:
+                    formatted_qualifiers = []
+                    for qualifier in qualifier_results:
+                        formatted_qualifiers.append({
+                            "qualifier_type_id": f"biolink:{qualifier['original_attribute_name']}"
+                            if not qualifier['original_attribute_name'].startswith("biolink:")
+                            else qualifier['original_attribute_name'],
+                            "qualifier_value": qualifier['value']
+                        })
+                    props['qualifiers'] = formatted_qualifiers
+
+            # create a new list that doesnt have the core properties or qualifiers
             new_attribs = [attrib for attrib in attributes
-                           if attrib['original_attribute_name'] not in props and attrib['original_attribute_name']
-                           not in skip_list
+                           if attrib['original_attribute_name'] not in props and
+                           attrib['original_attribute_name'] not in skip_list and
+                           'qualifie' not in attrib['original_attribute_name']
                            ]
 
             # for the non-core properties
@@ -87,29 +104,29 @@ class Question:
                     if attribute_data:
                         attr.update(attribute_data)
 
-            # create a provenance attribute for plater
-            provenance_attrib = {
-                "attribute_type_id": "biolink:aggregator_knowledge_source",
-                "value": [self.provenance],
-                "value_type_id": "biolink:InformationResource",
-                "original_attribute_name": "biolink:aggregator_knowledge_source"
-            }
-
-            # add plater provenance to the list
+            # update edge provenance with automat infores
             if not node:
-                # Adds attribute source for provenance attributes to edges.
-                new_attribs.append(provenance_attrib)
+                found_previous_aggregator = False
+                for attribute in new_attribs:
+                    if attribute.get('attribute_type_id') == "biolink:primary_knowledge_source":
+                        # setting this to self provenance (eg. infores:automat-biolink).
+                        attribute['attribute_source'] = self.provenance
+                    elif attribute.get('attribute_type_id') == "biolink:aggregator_knowledge_source":
+                        found_previous_aggregator = True
+                        attribute['attribute_source'] = self.provenance
+                        attribute['value'].append(self.provenance)  # add automat infores
+                        attribute['value'] = list(set(attribute['value']))  # force uniqueness
 
-            # setting this to self provenance (eg. infores:automat-biolink).
-            for attribute in new_attribs:
-                if attribute.get('attribute_type_id') in [
-                    "biolink:original_knowledge_source",
-                    "biolink:primary_knowledge_source",
-                    "biolink:aggregator_knowledge_source"
-                ] and attribute.get('value_type_id') == "biolink:InformationResource":
-                    attribute['attribute_source'] = self.provenance
-                    # convert to list for uniformity
-                    attribute['value'] = [attribute['value']] if isinstance(attribute['value'], str) else attribute['value']
+                # create aggregator provenance attribute for plater if not present
+                if not found_previous_aggregator:
+                    provenance_attrib = {
+                        "attribute_type_id": "biolink:aggregator_knowledge_source",
+                        "attribute_source": self.provenance,
+                        "value": [self.provenance],
+                        "value_type_id": "biolink:InformationResource",
+                        "original_attribute_name": "biolink:aggregator_knowledge_source"
+                    }
+                    new_attribs.append(provenance_attrib)
 
             # assign these attribs back to the original attrib list without the core properties
             props['attributes'] = new_attribs

--- a/PLATER/tests/data/trapi1.3.json
+++ b/PLATER/tests/data/trapi1.3.json
@@ -215,12 +215,10 @@
             "attribute_source": "infores:automat-robokop"
           },
           {
-            "attribute_type_id": "biolink:original_knowledge_source",
-            "value": [
-              "infores:sider"
-            ],
+            "attribute_type_id": "biolink:primary_knowledge_source",
+            "value": "infores:sider",
             "value_type_id": "biolink:InformationResource",
-            "original_attribute_name": "biolink:original_knowledge_source",
+            "original_attribute_name": "biolink:primary_knowledge_source",
             "attribute_source": "infores:automat-robokop"
           },
           {
@@ -258,12 +256,10 @@
             "attributes": null
           },
           {
-            "attribute_type_id": "biolink:original_knowledge_source",
-            "value": [
-              "infores:original_source_1"
-            ],
+            "attribute_type_id": "biolink:primary_knowledge_source",
+            "value": "infores:original_source_1",
             "value_type_id": "biolink:InformationResource",
-            "original_attribute_name": "biolink:original_knowledge_source",
+            "original_attribute_name": "biolink:primary_knowledge_source",
             "value_url": null,
             "attribute_source": "infores:automat-robokop",
             "description": null,
@@ -299,12 +295,10 @@
         "predicate": "biolink:contributes_to",
         "attributes": [
           {
-            "attribute_type_id": "biolink:original_knowledge_source",
-            "value": [
-              "infores:ctd"
-            ],
+            "attribute_type_id": "biolink:primary_knowledge_source",
+            "value": "infores:ctd",
             "value_type_id": "biolink:InformationResource",
-            "original_attribute_name": "biolink:original_knowledge_source",
+            "original_attribute_name": "biolink:primary_knowledge_source",
             "attribute_source": "infores:automat-robokop"
           },
           {

--- a/PLATER/tests/test_overlay.py
+++ b/PLATER/tests/test_overlay.py
@@ -137,8 +137,7 @@ def get_kg_ids(bindings):
 
 def test_overlay_adds_support_bindings(graph_interface_apoc_supported, reasoner_json):
     ov = Overlay(graph_interface=graph_interface_apoc_supported)
-    event_loop = asyncio.get_event_loop()
-    response = event_loop.run_until_complete(ov.connect_k_nodes(reasoner_json))
+    response = asyncio.run(ov.connect_k_nodes(reasoner_json))
     edges = response['knowledge_graph']['edges']
     edge_ids = edges.keys()
     assert len(edge_ids) == 2

--- a/PLATER/tests/test_question.py
+++ b/PLATER/tests/test_question.py
@@ -30,16 +30,33 @@ def test_format_attribute():
     # note that this test does not run through the reasoner code that does the attribute mapping.
     # so the values in the expected results must account for that
 
-    trapi_kg_response = {"knowledge_graph": {"nodes": {"CURIE:1": {"attributes": [
-        {"original_attribute_name": "pub", "attribute_type_id": "CURIE:x"},
-        {"original_attribute_name": "biolink:original_knowledge_source", "value": "infores:kg_source"}]
-    }}}}
-
-    expected_trapi = {"knowledge_graph": {"nodes": {"CURIE:1": {"attributes": [
-        {"original_attribute_name": "pub", "attribute_type_id": "CURIE:x", "value_type_id": "EDAM:data_0006"},
-        {"attribute_source": "infores:automat.notspecified", "original_attribute_name": "biolink:original_knowledge_source", "value": ["infores:kg_source"], "attribute_type_id": "biolink:original_knowledge_source", "value_type_id": "biolink:InformationResource"}]
-    }}}}
-
+    trapi_kg_response = {"knowledge_graph":
+        {"nodes":
+            {"CURIE:1":
+                {"attributes": [{"original_attribute_name": "pub", "attribute_type_id": "CURIE:x"}]}
+             },
+         "edges":
+             {"123123":
+                  {"attributes": [{"original_attribute_name": "biolink:primary_knowledge_source", "value": "infores:kg_source"}]}
+              }
+         }
+    }
+    expected_trapi = {"knowledge_graph":
+        {"nodes":
+            {"CURIE:1":
+                {"attributes": [{"original_attribute_name": "pub", "attribute_type_id": "CURIE:x", "value_type_id": "EDAM:data_0006"}]}
+             },
+         "edges":
+             {"123123":
+                  {"attributes": [{"original_attribute_name": "biolink:primary_knowledge_source", "value": "infores:kg_source",
+                                   "attribute_source": "infores:automat.notspecified", "attribute_type_id": "biolink:primary_knowledge_source",
+                                   "value_type_id": "biolink:InformationResource"},
+                                  {'attribute_type_id': 'biolink:aggregator_knowledge_source',  'attribute_source': 'infores:automat.notspecified',
+                                   'value': ['infores:automat.notspecified'],
+                                   'value_type_id': 'biolink:InformationResource', 'original_attribute_name': 'biolink:aggregator_knowledge_source'}]}
+              }
+         }
+    }
     q = Question(question_json={})
     graph_interface = MOCK_GRAPH_ADAPTER()
     transformed = q.transform_attributes(trapi_kg_response, graph_interface=MOCK_GRAPH_ADAPTER)
@@ -54,8 +71,7 @@ def test_format_attribute():
         {"original_attribute_name": "endogenous", "value": "false"},
         {"original_attribute_name": "p-value", "value": "1.234"},
         {"original_attribute_name": "chi-squared-statistic", "value": "2.345"},
-        {"original_attribute_name": "equivalent_identifiers", "attribute_type_id": "biolink:same_as", "value": ["some_identifier"]},
-        {"original_attribute_name": "biolink:original_knowledge_source", "value": "infores:kg_source"}]
+        {"original_attribute_name": "equivalent_identifiers", "attribute_type_id": "biolink:same_as", "value": ["some_identifier"]}]
     }}}}
 
     t2_expected_trapi = {'knowledge_graph': {'nodes': {'CURIE:1': {'attributes': [
@@ -64,8 +80,7 @@ def test_format_attribute():
         {'original_attribute_name': 'endogenous', 'value': 'false', 'value_type_id': 'xsd:boolean', 'attribute_type_id': 'aragorn:endogenous'},
         {'original_attribute_name': 'p-value', 'value': '1.234', 'value_type_id': 'EDAM:data_0006', 'attribute_type_id': 'biolink:Attribute'},
         {'original_attribute_name': 'chi-squared-statistic', 'value': '2.345', 'value_type_id': 'EDAM:data_0006', 'attribute_type_id': 'biolink:Attribute'},
-        {"original_attribute_name": "equivalent_identifiers", "attribute_type_id": "biolink:same_as", "value": ["some_identifier"], 'value_type_id': 'metatype:uriorcurie'},
-        {"attribute_source": "infores:automat.notspecified", "original_attribute_name": "biolink:original_knowledge_source", "value": ["infores:kg_source"], "attribute_type_id": "biolink:original_knowledge_source", "value_type_id": "biolink:InformationResource"}
+        {"original_attribute_name": "equivalent_identifiers", "attribute_type_id": "biolink:same_as", "value": ["some_identifier"], 'value_type_id': 'metatype:uriorcurie'}
     ]
     }}}}
 
@@ -84,9 +99,10 @@ def test_format_edge_qualifiers():
     trapi_kg_response ={ "knowledge_graph": {
        "edges":{
           "some_id":{
-             "predicate":"biolink:affects",
-             "subject":"PUBCHEM.COMPOUND:5311062",
-             "attributes":[
+              "object": "NCBIGene:283871",
+              "predicate": "biolink:affects",
+              "subject": "PUBCHEM.COMPOUND:5311062",
+              "attributes": [
                 {
                    "attribute_type_id":"NA",
                    "original_attribute_name":"qualified_predicate",
@@ -94,41 +110,43 @@ def test_format_edge_qualifiers():
                 },
                 {
                    "attribute_type_id":"NA",
-                   "original_attribute_name":"object_aspect",
+                   "original_attribute_name":"object_aspect_qualifier",
                    "value":"activity"
                 },
                 {
                    "attribute_type_id":"NA",
-                   "original_attribute_name":"object_direction",
+                   "original_attribute_name":"object_direction_qualifier",
                    "value":"decreased"
-                }
-             ],
-             "object":"NCBIGene:283871"
+                }],
           }
        }
-    } }
+    }}
     expected_trapi = {"knowledge_graph": {"edges": {'some_id': {
-                                              'attributes': [{'attribute_type_id': 'biolink:qualified_predicate',
-                                                              'original_attribute_name': 'qualified_predicate',
-                                                              'value': 'biolink:causes',
-                                                              'value_type_id': 'EDAM:data_0006'},
-                                                             {'attribute_type_id': 'biolink:object_aspect_qualifier',
-                                                              'original_attribute_name': 'object_aspect',
-                                                              'value': 'activity',
-                                                              'value_type_id': 'EDAM:data_0006'},
-                                                             {'attribute_type_id': 'biolink:object_direction_qualifier',
-                                                              'original_attribute_name': 'object_direction',
-                                                              'value': 'decreased',
-                                                              'value_type_id': 'EDAM:data_0006'},
-                                                             {'attribute_source': 'infores:automat.notspecified',
-                                                              'attribute_type_id': 'biolink:aggregator_knowledge_source',
-                                                              'original_attribute_name': 'biolink:aggregator_knowledge_source',
-                                                              'value': ['infores:automat.notspecified'],
-                                                              'value_type_id': 'biolink:InformationResource'}],
-                                              'object': 'NCBIGene:283871',
-                                              'predicate': 'biolink:affects',
-                                              'subject': 'PUBCHEM.COMPOUND:5311062'}}
-                                          }}
+        'object': 'NCBIGene:283871',
+        'predicate': 'biolink:affects',
+        'subject': 'PUBCHEM.COMPOUND:5311062',
+        'attributes': [
+            {'attribute_type_id': 'biolink:aggregator_knowledge_source',
+             'attribute_source': 'infores:automat.notspecified',
+             'value': ['infores:automat.notspecified'],
+             'value_type_id': 'biolink:InformationResource',
+             'original_attribute_name': 'biolink:aggregator_knowledge_source'}],
+        "qualifiers": [
+            {
+                "qualifier_type_id": "biolink:qualified_predicate",
+                "qualifier_value": "biolink:causes"
+            },
+            {
+                "qualifier_type_id": "biolink:object_aspect_qualifier",
+                "qualifier_value": "activity"
+            },
+            {
+                "qualifier_type_id": "biolink:object_direction_qualifier",
+                "qualifier_value": "decreased"
+            },
+        ],
+        }}
+    }}
 
     q = Question(question_json={})
     graph_interface = MOCK_GRAPH_ADAPTER()
@@ -207,7 +225,7 @@ def test_attribute_constraint_filter_edge(message):
            result['knowledge_graph']['edges']['57de50b7d36a7b952a12376ae39c1f92']
     assert len(result['results']) == 1
     edge_constraints = [
-        {"id": "biolink:original_knowledge_source", "name": "eq_id_filter", "value": ['infores:original_source_1'], "operator": "=="}
+        {"id": "biolink:primary_knowledge_source", "name": "eq_id_filter", "value": 'infores:original_source_1', "operator": "=="}
     ]
     message['query_graph']['edges']['e0']['attribute_constraints'] = edge_constraints
     result = Question.apply_attribute_constraints(message)

--- a/attr_val_map.json
+++ b/attr_val_map.json
@@ -1,6 +1,5 @@
 {
   "attribute_type_map": {
-      "`biolink:original_knowledge_source`": "biolink:original_knowledge_source",
       "`biolink:primary_knowledge_source`": "biolink:primary_knowledge_source",
       "`biolink:aggregator_knowledge_source`": "biolink:aggregator_knowledge_source",
       "equivalent_identifiers": "biolink:same_as",
@@ -8,7 +7,6 @@
   },
   "value_type_map": {
       "equivalent_identifiers": "metatype:uriorcurie",
-      "biolink:original_knowledge_source": "biolink:InformationResource",
       "biolink:primary_knowledge_source": "biolink:InformationResource",
       "biolink:aggregator_knowledge_source": "biolink:InformationResource",
       "endogenous": "xsd:boolean"


### PR DESCRIPTION
updated to fix qualifier output format, separating qualifiers from other attributes,
altered primary knowledge source to only have one string value (previously a list),
altered aggregator knowledge source so that it appends to sources in graphs instead of overwriting,
removed deprecated original_knowlede_source,
changed so that knowledge sources are only handled on edges and not nodes,
changed so that all parameters with "qualifie" in them are treated as qualifiers for some amount of future proofing, 
updated tests to reflect all these changes

added example with qualifiers and updated node ids,