### PR TITLE
Transpiler and pydantic updates

### DIFF
--- a/PLATER/requirements.txt
+++ b/PLATER/requirements.txt
@@ -5,7 +5,7 @@ pytest==6.2.4
 pytest-asyncio==0.15.1
 starlette==0.20.4
 uvicorn==0.14.0
-reasoner-transpiler==2.0.1
+reasoner-transpiler==2.0.2
 reasoner-pydantic==4.0.6
 httpx==0.18.2
 pytest-httpx==0.12.0

--- a/PLATER/requirements.txt
+++ b/PLATER/requirements.txt
@@ -6,7 +6,7 @@ pytest-asyncio==0.15.1
 starlette==0.20.4
 uvicorn==0.14.0
 reasoner-transpiler==2.0.1
-reasoner-pydantic==4.0.5
+reasoner-pydantic==4.0.6
 httpx==0.18.2
 pytest-httpx==0.12.0
 jsonasobj==1.3.1

--- a/PLATER/services/app_trapi_1_4.py
+++ b/PLATER/services/app_trapi_1_4.py
@@ -19,16 +19,16 @@ async def get_meta_knowledge_graph(
         graph_metadata: GraphMetadata = Depends(get_graph_metadata),
 ) -> MetaKnowledgeGraph:
     """Handle /meta_knowledge_graph."""
-    response = await graph_metadata.get_meta_kg()
-    return response
+    meta_kg = await graph_metadata.get_meta_kg()
+    return meta_kg
 
 
 async def get_sri_testing_data(
         graph_metadata: GraphMetadata = Depends(get_graph_metadata),
 ) -> SRITestData:
     """Handle /sri_testing_data."""
-    response = await graph_metadata.get_sri_testing_data()
-    return response
+    sri_test_data = await graph_metadata.get_sri_testing_data()
+    return sri_test_data
 
 
 async def reasoner_api(
@@ -48,20 +48,20 @@ async def reasoner_api(
     if 'lookup' in workflows:
         question = Question(request_json["message"])
         try:
-            answer = await question.answer(graph_interface)
-            request_json.update({'message': answer, 'workflow': workflow})
+            response_message = await question.answer(graph_interface)
+            request_json.update({'message': response_message, 'workflow': workflow})
         except InvalidPredicateError as e:
             response.status_code = status.HTTP_400_BAD_REQUEST
             request_json["description"] = str(e)
             return request_json
     elif 'overlay_connect_knodes' in workflows:
         overlay = Overlay(graph_interface=graph_interface)
-        response = await overlay.connect_k_nodes(request_json['message'])
-        request_json.update({'message': response, 'workflow': workflow})
+        response_message = await overlay.connect_k_nodes(request_json['message'])
+        request_json.update({'message': response_message, 'workflow': workflow})
     elif 'annotate_nodes' in workflows:
         overlay = Overlay(graph_interface=graph_interface)
-        response = await overlay.annotate_node(request_json['message'])
-        request_json.update({'message': response, 'workflow': workflow})
+        response_message = await overlay.annotate_node(request_json['message'])
+        request_json.update({'message': response_message, 'workflow': workflow})
     return request_json
 
 

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -11,7 +11,7 @@ from PLATER.services.util.api_utils import construct_open_api_schema
 
 TITLE = config.get('PLATER_TITLE', 'Plater API')
 
-VERSION = os.environ.get('PLATER_VERSION', '1.3.0-13')
+VERSION = os.environ.get('PLATER_VERSION', '1.4.0-2')
 
 
 logger = LoggingUtil.init_logging(

--- a/PLATER/services/util/api_utils.py
+++ b/PLATER/services/util/api_utils.py
@@ -34,7 +34,7 @@ def get_bl_helper():
 
 def construct_open_api_schema(app, trapi_version, prefix=""):
     plater_title = config.get('PLATER_TITLE', 'Plater API')
-    plater_version = os.environ.get('PLATER_VERSION', '1.4.0-0')
+    plater_version = os.environ.get('PLATER_VERSION', '1.4.0-2')
     server_url = os.environ.get('PUBLIC_URL', '')
     if app.openapi_schema:
         return app.openapi_schema


### PR DESCRIPTION
bumping transpiler and pydantic versions
catching InvalidPredicateError from the transpiler and returning 400 status in those cases

transpiler changes include:
 - removed checks for primary knowledge source
 - now checking for subclass and superclass predicates in queries and preventing subclass inference for nodes on those edges
- added InvalidPredicateError exception, thrown when a predicate unknown to the biolink model is encountered