### PR TITLE
Add environment variable to enforce non-TLS http:// trace exporter as needed

### DIFF
--- a/PLATER/requirements.txt
+++ b/PLATER/requirements.txt
@@ -9,11 +9,11 @@ httpx==0.27.2
 pytest-httpx==0.32.0
 pydantic==1.10.2
 orjson==3.10.7
-opentelemetry-sdk==1.41.1
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-opentelemetry-exporter-otlp-proto-common==1.41.1
-opentelemetry-proto==1.41.1
-opentelemetry-api==1.41.1
-opentelemetry-instrumentation-fastapi==0.62b1
+opentelemetry-sdk==1.28.2
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
+opentelemetry-exporter-otlp-proto-common==1.28.2
+opentelemetry-proto==1.28.2
+opentelemetry-api==1.28.2
+opentelemetry-instrumentation-fastapi==0.49b2
 pyinstrument==4.7.3
 neo4j-rust-ext==5.28.0

--- a/PLATER/requirements.txt
+++ b/PLATER/requirements.txt
@@ -9,8 +9,11 @@ httpx==0.27.2
 pytest-httpx==0.32.0
 pydantic==1.10.2
 orjson==3.10.7
-opentelemetry-sdk==1.27.0
-opentelemetry-exporter-otlp-proto-grpc==1.27.0
-opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-sdk==1.28.2
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
+opentelemetry-exporter-otlp-proto-common==1.28.2
+opentelemetry-proto==1.28.2
+opentelemetry-api==1.28.2
+opentelemetry-instrumentation-fastapi==0.49b2
 pyinstrument==4.7.3
 neo4j-rust-ext==5.28.0

--- a/PLATER/requirements.txt
+++ b/PLATER/requirements.txt
@@ -9,11 +9,11 @@ httpx==0.27.2
 pytest-httpx==0.32.0
 pydantic==1.10.2
 orjson==3.10.7
-opentelemetry-sdk==1.28.2
-opentelemetry-exporter-otlp-proto-grpc==1.28.2
-opentelemetry-exporter-otlp-proto-common==1.28.2
-opentelemetry-proto==1.28.2
-opentelemetry-api==1.28.2
-opentelemetry-instrumentation-fastapi==0.49b2
+opentelemetry-sdk==1.41.1
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+opentelemetry-exporter-otlp-proto-common==1.41.1
+opentelemetry-proto==1.41.1
+opentelemetry-api==1.41.1
+opentelemetry-instrumentation-fastapi==0.62b1
 pyinstrument==4.7.3
 neo4j-rust-ext==5.28.0

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -42,7 +42,8 @@ if config.get("OTEL_ENABLED", "False") not in ("false", "False"):
         otlp_host = config.get("JAEGER_HOST", "http://localhost/").rstrip('/')
         otlp_port = config.get("JAEGER_PORT", "4317")
         otlp_endpoint = f'{otlp_host}:{otlp_port}'
-        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}')
+        otlp_insecure = config.get("OTEL_EXPORTER_OTLP_INSECURE", "false").lower() == "true"
+        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}', insecure=otlp_insecure)
         processor = BatchSpanProcessor(otlp_exporter)
 
     provider.add_span_processor(processor)

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -42,11 +42,7 @@ if config.get("OTEL_ENABLED", "False") not in ("false", "False"):
         otlp_host = config.get("JAEGER_HOST", "http://localhost/").rstrip('/')
         otlp_port = config.get("JAEGER_PORT", "4317")
         otlp_endpoint = f'{otlp_host}:{otlp_port}'
-        # In both SDK versions 1.27 and 1.28, OTLPSpanExporter does not respect http:// scheme in endpoint
-        # and uses secure channel automatically. OTEL_EXPORTER_OTLP_INSECURE env var is introduced to force 
-        # insecure channel for environments on http:// endpoints.
-        otlp_insecure = config.get("OTEL_EXPORTER_OTLP_INSECURE", "false").lower() == "true"
-        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}', insecure=otlp_insecure)
+        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}')
         processor = BatchSpanProcessor(otlp_exporter)
 
     provider.add_span_processor(processor)

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -42,7 +42,12 @@ if config.get("OTEL_ENABLED", "False") not in ("false", "False"):
         otlp_host = config.get("JAEGER_HOST", "http://localhost/").rstrip('/')
         otlp_port = config.get("JAEGER_PORT", "4317")
         otlp_endpoint = f'{otlp_host}:{otlp_port}'
-        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}')
+        # In SDK 1.28+, OTLPSpanExporter respects http:// scheme in endpoint
+        # and uses insecure channel automatically — no insecure= flag needed.
+        # OTEL_EXPORTER_OTLP_INSECURE env var is kept as an explicit override
+        # for environments that need to force insecure on https:// endpoints.
+        otlp_insecure = config.get("OTEL_EXPORTER_OTLP_INSECURE", "false").lower() == "true"
+        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}', insecure=otlp_insecure)
         processor = BatchSpanProcessor(otlp_exporter)
 
     provider.add_span_processor(processor)

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -42,8 +42,7 @@ if config.get("OTEL_ENABLED", "False") not in ("false", "False"):
         otlp_host = config.get("JAEGER_HOST", "http://localhost/").rstrip('/')
         otlp_port = config.get("JAEGER_PORT", "4317")
         otlp_endpoint = f'{otlp_host}:{otlp_port}'
-        otlp_insecure = config.get("OTEL_EXPORTER_OTLP_INSECURE", "false").lower() == "true"
-        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}', insecure=otlp_insecure)
+        otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}')
         processor = BatchSpanProcessor(otlp_exporter)
 
     provider.add_span_processor(processor)

--- a/PLATER/services/server.py
+++ b/PLATER/services/server.py
@@ -42,10 +42,9 @@ if config.get("OTEL_ENABLED", "False") not in ("false", "False"):
         otlp_host = config.get("JAEGER_HOST", "http://localhost/").rstrip('/')
         otlp_port = config.get("JAEGER_PORT", "4317")
         otlp_endpoint = f'{otlp_host}:{otlp_port}'
-        # In SDK 1.28+, OTLPSpanExporter respects http:// scheme in endpoint
-        # and uses insecure channel automatically — no insecure= flag needed.
-        # OTEL_EXPORTER_OTLP_INSECURE env var is kept as an explicit override
-        # for environments that need to force insecure on https:// endpoints.
+        # In both SDK versions 1.27 and 1.28, OTLPSpanExporter does not respect http:// scheme in endpoint
+        # and uses secure channel automatically. OTEL_EXPORTER_OTLP_INSECURE env var is introduced to force 
+        # insecure channel for environments on http:// endpoints.
         otlp_insecure = config.get("OTEL_EXPORTER_OTLP_INSECURE", "false").lower() == "true"
         otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}', insecure=otlp_insecure)
         processor = BatchSpanProcessor(otlp_exporter)


### PR DESCRIPTION
Add environment variable to enforce non-TLS http:// trace exporter since upgrading telemetry SDK version itself is not sufficient to enforce TLS security automatically according to http/https scheme.